### PR TITLE
:bug: Background image fixes

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,6 +19,9 @@ a {
   box-sizing: border-box;
 }
 
+#__next > span,
 .page-bg {
+  position: fixed !important;
   z-index: -1;
+  pointer-events: none;
 }


### PR DESCRIPTION
Adds `position: fixed` and `pointer-events: none` to background images so they don't scroll and aren't clickable.